### PR TITLE
Update addresses.js

### DIFF
--- a/public/emu/addresses.js
+++ b/public/emu/addresses.js
@@ -5,7 +5,8 @@
 // id to [address, num_bytes]
 const gym6_data_maps = {
 	gameMode: [0xc0, 1], // gameMode
-	playState: [0x48, 1], // gameModeState
+	playState: [0x48, 1], // playState
+	gameModeState: [0xA7, 1], // gameModeState
 	completedRowXClear: [0x52, 1], // rowY (rowY is a terrible name in Rom)
 	completedRows: [0x4a, 4], // completedRow
 	lines: [0x50, 2], // lines


### PR DESCRIPTION
Reference commit:  https://github.com/nestrischamps/nestrischamps/commit/4c4ce2b81dc8c45b390dd318ea44c7ca9c10f7af and #213

The naming is probably confusing.  playState and gameModeState are separate variables in gym, but for the edlink they're combined into a single byte to save space as neither would exceed 4 bits.   